### PR TITLE
Market communism for vassals and spherelings

### DIFF
--- a/CWE/decisions/Globalization.txt
+++ b/CWE/decisions/Globalization.txt
@@ -242,6 +242,8 @@ NOT = { has_global_flag = end_of_bretton_system }
 				is_secondary_power = yes
 				is_greater_power = yes
 				sphere_owner = { has_country_modifier = bretton_system } 
+				sphere_owner = { has_country_modifier = market_communism } 
+				overlord = { has_country_modifier = market_communism } 
 			}
 		}
 		effect = {


### PR DESCRIPTION
Allows embracing market communism if either your overlord or sphere leader embraced it. While unsphered vassal communist regimes are relatively rare, they tend to occur in Yugoslavia, so checking for overlord is not redundant.